### PR TITLE
Allows specifying SASS_ROOT and SASS_URL.

### DIFF
--- a/sass/listeners.py
+++ b/sass/listeners.py
@@ -1,17 +1,14 @@
 import os
-
 from django.db.models import signals
-from django.conf import settings
-
 from sass.models import SassModel
 
 
 def set_last_modified_time(sender, instance, **kwargs):
     # set the last modified time based on the os.stat system call.
     st_mtime = 8  # last_modified_time column
-    last_modified_time = os.stat(instance.sass_path)[8]
+    last_modified_time = os.stat(instance.sass_path)[st_mtime]
     instance.source_modified_time = last_modified_time
-    
+
 
 def start_listening():
     signals.pre_save.connect(set_last_modified_time, sender=SassModel)

--- a/sass/management/commands/sassify.py
+++ b/sass/management/commands/sassify.py
@@ -1,15 +1,14 @@
-import sys, os
+import os
 from optparse import make_option
 from commands import getstatusoutput
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.core.management.color  import no_style
-from django.utils.http import urlquote
 
 from sass.models import SASS_ROOT, SassModel
 from sass.utils import update_needed
-from sass.exceptions import SassConfigException, SassConfigurationError, SassCommandArgumentError, SassGenerationError, SassException
+from sass.exceptions import SassConfigException, SassConfigurationError, SassCommandArgumentError, SassException
 
 
 class Command(BaseCommand):
@@ -65,7 +64,7 @@ class Command(BaseCommand):
         elif clean:
             self.clean()
         else:
-            self.process_sass(force=kwargs.get('force_sass'))
+            self.process_sass(force=force)
 
 
     def get_sass_definitions(self):

--- a/sass/management/commands/sassify.py
+++ b/sass/management/commands/sassify.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management.color  import no_style
 from django.utils.http import urlquote
 
-from sass.models import SassModel
+from sass.models import SASS_ROOT, SassModel
 from sass.utils import update_needed
 from sass.exceptions import SassConfigException, SassConfigurationError, SassCommandArgumentError, SassGenerationError, SassException
 
@@ -17,24 +17,24 @@ class Command(BaseCommand):
         The user may whish to keep their sass files in their MEDIA_ROOT directory,
         or they may wish them to be somewhere outsite - even outside their project
         directory. We try to support both.
-        
-        The same is true for the CSS output file. We recommend putting it in the 
+
+        The same is true for the CSS output file. We recommend putting it in the
         MEDIA_ROOT but if there is a reason not to, we support that as well.
     """
-    
+
     requires_model_validation = False
     can_import_settings = True
     style = no_style()
-    
-    option_list = BaseCommand.option_list + ( 
+
+    option_list = BaseCommand.option_list + (
         make_option('--style', '-t', dest='sass_style', default='nested', help='Sass output style. Can be nested (default), compact, compressed, or expanded.'),
         make_option('--list', '-l', action='store_true', dest='list_sass' , default=None, help='Display information about the status of your sass files.'),
         make_option('--force', '-f', action='store_true', dest='force_sass', default=False, help='Force sass to run.'),
         make_option('--clean', '-c', action='store_true', dest='clean', default=False, help='Remove all the generated CSS files.'),
     )
     help = 'Converts Sass files into CSS.'
-    
-    
+
+
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)
         self.bin = getattr(settings, "SASS_BIN", None)
@@ -43,23 +43,23 @@ class Command(BaseCommand):
         # test that the binary actually exists.
         if not os.path.exists(self.bin):
             raise SassConfigurationError('Sass binary defined by SASS_BIN does not exist: %s' % self.bin)
-            
+
         self.sass_style = getattr(settings, "SASS_STYLE", 'nested')
-    
-    
+
+
     def handle(self, *args, **kwargs):
         # make sure the Sass style given is valid.
         self.sass_style = kwargs.get('sass_style')
         if self.sass_style not in ('nested', 'compact', 'compressed', 'expanded'):
             raise SassCommandArgumentError("Invalid sass style argument: %s" % self.sass_style)
-        
+
         force = kwargs.get('force_sass')
         list_sass = kwargs.get('list_sass')
         clean = kwargs.get('clean')
-        
+
         # we process the args in the order of least importance to hopefully stop
         # any unwanted permanent behavior.
-        
+
         if list_sass:
             self.list()
         elif clean:
@@ -74,15 +74,15 @@ class Command(BaseCommand):
             try:
                 sd = {
                     'name' : sass_def['name'],
-                    'input_file' : os.path.join(settings.MEDIA_ROOT, sass_def['details']['input']),
-                    'output_file' : os.path.join(settings.MEDIA_ROOT, sass_def['details']['output']),
+                    'input_file' : os.path.join(SASS_ROOT, sass_def['details']['input']),
+                    'output_file' : os.path.join(SASS_ROOT, sass_def['details']['output']),
                     # 'media_output' : settings.MEDIA_URL + urlquote(sass_def['details']['output']),
                 }
                 definitions.append(sd)
             except KeyError:
                 raise SassConfigurationError("Improperly defined SASS definition.")
         return definitions
-        
+
 
     def process_sass(self, name=None, force=False):
         if force:
@@ -91,7 +91,7 @@ class Command(BaseCommand):
         for sass_def in sass_definitions:
             if not name or name == sass_def['name']:
                 self.generate_css_file(force=force, **sass_def)
-            
+
 
 
     def generate_css_file(self, force, name, input_file, output_file, **kwargs):
@@ -108,17 +108,17 @@ class Command(BaseCommand):
             except AttributeError, e:
                 # we have an older version of python that doesn't support os.mkdirs - fail gracefully.
                 raise SassConfigException('Output path does not exist - please create manually: %s\n' %output_path)
-                
+
         try:
             sass_obj = SassModel.objects.get(name=name)
             was_created = False
         except SassModel.DoesNotExist:
             sass_obj = SassModel(name=name)
             was_created = True
-            
-        sass_obj.sass_path = input_file 
+
+        sass_obj.sass_path = input_file
         sass_obj.css_path = output_file
-        
+
         needs_update = was_created or force or update_needed(sass_obj)
         if needs_update:
             sass_dict = { 'bin' : self.bin, 'sass_style' : self.sass_style, 'input' : input_file, 'output' : output_file }
@@ -127,8 +127,8 @@ class Command(BaseCommand):
             if not status == 0:
                 raise SassException(output)
             sass_obj.save()
-    
-    
+
+
     def clean(self):
         for s in SassModel.objects.all():
             try:
@@ -137,12 +137,12 @@ class Command(BaseCommand):
                 s.delete()
             except OSError, e:
                 raise e
-    
-    
+
+
     def list(self):
         """
         We check to see if the Sass outlined in the SASS setting are different from what the databse
-        has stored. We only care about listing those files that are in the SASS setting. Ignore the 
+        has stored. We only care about listing those files that are in the SASS setting. Ignore the
         settings in the DB if the files/settings have been removed.
         """
         # process the Sass information in the settings.
@@ -160,4 +160,3 @@ class Command(BaseCommand):
             needs_update = was_created or update_needed(sass_obj)
             if needs_update:
                 print "\tChanges detected."
-        

--- a/sass/models.py
+++ b/sass/models.py
@@ -2,6 +2,9 @@ from django.db import models
 from django.conf import settings
 from django.utils.http import urlquote
 
+SASS_ROOT = getattr(settings, 'SASS_ROOT', settings.MEDIA_ROOT)
+SASS_URL = getattr(settings, 'SASS_URL', settings.MEDIA_URL)
+
 
 class SassModel(models.Model):
     name = models.CharField(max_length=60, primary_key=True, help_text='Name of the Sass conversion.')
@@ -9,16 +12,17 @@ class SassModel(models.Model):
     css_path = models.CharField(max_length=255, help_text='Path to the generated CSS file.')
     style = models.CharField(choices='', max_length=10, help_text='The style used when creating the css file.')
     source_modified_time = models.CharField(max_length=12, help_text='Last time the source file was modified.')
-    
+
     def __unicode__(self):
         return self.name
-        
+
     def relative_css_path(self):
-        return self.css_path.split(settings.MEDIA_ROOT)[1].lstrip('/')
-        
+        print self.css_path.split(SASS_ROOT)[1].lstrip('/')
+        return self.css_path.split(SASS_ROOT)[1].lstrip('/')
+
     def css_media_path(self):
-        return settings.MEDIA_URL + urlquote(self.relative_css_path())
-        
+        return SASS_URL + urlquote(self.relative_css_path())
+
 
 from sass import listeners
 listeners.start_listening()

--- a/sass/templatetags/sass_tag.py
+++ b/sass/templatetags/sass_tag.py
@@ -1,12 +1,5 @@
-import os
-
 from django import template
-from django.conf import settings
-from django.utils.http import urlquote
-
-from sass.utils import SassUtils
 from sass.models import SassModel
-
 from sass.management.commands import sassify
 
 
@@ -18,12 +11,11 @@ class SassNode(template.Node):
             command = sassify.Command()
             command.process_sass(name=name)
             self.model = SassModel.objects.get(name=name)
-        except SassModel.DoesNotExist, e:
+        except SassModel.DoesNotExist:
             raise template.TemplateSyntaxError('Sass name "%s" does not exist.' % self.name)
-        
-        
+
+
     def render(self, context):
-        relative_css_path = self.model.relative_css_path()
         media_url = self.model.css_media_path()
         css = "<link href='%s?%s' rel='stylesheet' type='text/css' />" %(media_url, self.model.source_modified_time)
         return css
@@ -39,4 +31,3 @@ def do_sass(parser, token):
     if not (resource[0] == resource[-1] and resource[0] in ('"', "'")):
         raise template.TemplateSyntaxError, "%r tag's argument should be in quotes" % tag_name
     return SassNode(resource[1:-1])
-    

--- a/sass/utils.py
+++ b/sass/utils.py
@@ -8,19 +8,19 @@ from sass.models import SassModel
 from sass.exceptions import SassConfigException
 
 def update_needed(new_sass_model):
-    # check the database and see if the 
+    # check the database and see if the
     name = new_sass_model.name
     orig_sass_model = SassModel.objects.get(name=name)
-    
+
     # if the output file doesn't exist we need to update
     if not os.path.exists(new_sass_model.css_path):
         return True
-    
+
     # if the model has been modified, then we need to update.
     for key in ['sass_path', 'css_path', 'style',]:
         if not getattr(orig_sass_model, key)  == getattr(new_sass_model, key):
             return True
-    
+
     # if the source file has been updated, then we need to update.
     try:
         last_modified_time = os.stat(new_sass_model.sass_path)[8]
@@ -29,24 +29,24 @@ def update_needed(new_sass_model):
     except OSError:
         # file does not exist so we need to update
         return True
-        
+
     return False
 
 
 class SassUtils(object):
-    
+
     @staticmethod
     def get_file_path(path):
         if os.path.isabs(path):
             return path
         return settings.MEDIA_ROOT + os.path.sep + path
-    
-    
+
+
     @staticmethod
     def get_media_url(path, media_url=settings.MEDIA_URL):
         return media_url + urlquote(path)
-        
-    
+
+
     @staticmethod
     def build_sass_structure():
         sass_definitions = getattr(settings, "SASS", ())
@@ -62,9 +62,8 @@ class SassUtils(object):
                 # i hate generic exception message - try to give the user a meaningful message about what exactly the problem is.
                 for prop in [('name', sass_name), ('details', sass_details), ('input', sass_input), ('output', sass_output)]:
                     if not prop[1]:
-                        raise SassConfigException('Sass \'%s\' property not defined in configuration:\n%s\n' %(prop[0], sass_def))                
-            except SassConfigException, e:
-                sys.stderr.write(self.style.ERROR(e.message))
+                        raise SassConfigException('Sass \'%s\' property not defined in configuration:\n%s\n' %(prop[0], sass_def))
+            except SassConfigException:
                 return
             sass_input_root = SassUtils.get_file_path(sass_input)
             sass_output_root = SassUtils.get_file_path(sass_output)
@@ -76,8 +75,8 @@ class SassUtils(object):
                 'media_out' : sass_output_media,
             })
         return sass_struct
-       
-    
+
+
     @staticmethod
     def md5_file(filename):
         try:
@@ -90,4 +89,3 @@ class SassUtils(object):
             return md5.hexdigest()
         except IOError, e:
             raise SassConfigException(e.message)
-    


### PR DESCRIPTION
This has two commits.

1.) Allows specifying SASS_ROOT and SASS_URL instead of assuming the files are located in the MEDIA_ROOT.  This allows us to use the new STATIC_ROOT directories moving forward with Django 1.3+.  The settings will default back to MEDIA_ROOT and MEDIA_URL if not specified in settings for backward compatibility.  This fixes issue #7.

2.) General cleanup after running pyFlakes on the code.
